### PR TITLE
Fix two typos, improve formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Now open [localhost:8080](http://localhost:8080)
 
 ## Offline First
 
-This tutorial implments ServiceWorker and can be run offline using a Chrome or Firefox browser. To run offline, turn off the server (Ctrl + C) and refresh [localhost:8080](http://localhost:8080) using Chrome or Firefox. The tutorial page will still load.
+This tutorial implements ServiceWorker and can be run offline using a Chrome or Firefox browser. To run offline, turn off the server (<kbd>Ctrl</kbd> + <kbd>C</kbd>) and refresh [localhost:8080](http://localhost:8080) using Chrome or Firefox. The tutorial page will still load.
 
-To remove the offline tutorial from [localhost:8080](http://localhost:8080) visit chrome://serviceworker-internals/ if using Chrome, visit about:serviceworkers if using Firefox, or visit opera://serviceworker-internals/ if user Opera and unregister the ServiceWorker. 
+To remove the offline tutorial from [localhost:8080](http://localhost:8080) visit `chrome://serviceworker-internals/` if using Chrome, visit `about:serviceworkers` if using Firefox, or visit `opera://serviceworker-internals/` if using Opera and unregister the ServiceWorker. 
 
 Don’t worry if your browser doesn't support ServiceWorker yet, it only means that you can’t reload the page without the server running.
 


### PR DESCRIPTION
The typos are obvious :-)
I believe the URLs are better readable when formatted as code
